### PR TITLE
module: Rename it to use the repo name, liblc3

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,4 @@
-name: liblc3codec
+name: liblc3
 build:
   cmake-ext: True
   kconfig-ext: True


### PR DESCRIPTION
Makes no sense to keep the old name.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>